### PR TITLE
Refactor `profiling::main`

### DIFF
--- a/runtime/src/op/tests/intrinsics.rs
+++ b/runtime/src/op/tests/intrinsics.rs
@@ -52,6 +52,6 @@ fn test_panic() {
     assert_eq!(err.len(), 1);
     assert_eq!(
         err[0],
-        "Profiling panic: \npanicked at src/lib.rs:7:1:\noops"
+        "Profiling panic: \npanicked at src/lib.rs:10:5:\noops"
     );
 }


### PR DESCRIPTION
The `profiling::main` uses function block replacement to generate export functions for WASM runtime, which results in a less friendly compiler error message and panic with incorrect line numbers.

This patch refactores `profiling::main` by calling the original main function directly in the generated export functions to fix the above issues.